### PR TITLE
discard_feeのrate不備修正

### DIFF
--- a/src/cfd_utxo.cpp
+++ b/src/cfd_utxo.cpp
@@ -216,8 +216,8 @@ std::vector<Utxo> CoinSelection::SelectCoinsMinConf(
     const Amount& target_value, const std::vector<Utxo>& utxos,
     const UtxoFilter& filter, const CoinSelectionOption& option_params,
     Amount* select_value, Amount* fee_value) {
-  // for btc default(DUST_RELAY_TX_FEE)
-  static constexpr const uint64_t kDustRelayTxFee = 3000;
+  // for btc default(DUST_RELAY_TX_FEE(3000)) -> DEFAULT_DISCARD_FEE(10000)
+  static constexpr const uint64_t kDustRelayTxFee = 10000;
   if (select_value) {
     *select_value = Amount::CreateBySatoshiAmount(0);
   } else {


### PR DESCRIPTION
## 関連Issue

<!--
このPRが、ZenHubのどのIssueに紐づいているかを記載する
  - ZenHubのURL
-->

## 概要

<!--
- 追加機能の概要を記載
- 前提が共有されていない場合は、  
  なぜこの変更をして、  
  どう解決されるのかも併せて記載する

- 必要であれば、以下のような詳細についても記載する
  - 以下の観点で、レビューアーにわかるように技術的な変更点の概要を記載
    - 何をどう変更したか
    - どういった手法を採用したか  
      （e.g. パス探索については、幅優先探索を採用した）
    - 外部システムとのI/F変更
    - など
-->

- 不具合修正。cost_of_change の算出に使用するdiscard_fee のrateの初期値を誤っていた。
  - 3000 -> 10000 (3.0 -> 10.0)
  - 数値とコメントのみ修正

## 使い方

<!-- 
- PRの動作確認方法
  - 動作確認が必要なタスクについては、必要なコマンドなどを記載
  - 必要なければ、無記載で良い
-->

```bash
npm run cmake_all
npm run test_all
```

## 今回保留した項目とTODO

<!--
- 箇条書きで保留した項目があれば、記載
  - 保留項目が直近の対応が必要な場合、対応チケットを作成して記載

記載例
- 〇〇の計算ロジックの本実装 #0000
-->

- 

## 確認項目

**PRを出した人**
<!-- PRを出す前後で確認する項目 -->

- [ ] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [x] 正常にビルドできた
- [ ] 関連チケットに実績をつけた
- [ ] ZenHubでPRとIssueを関連付けた
- [ ] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [ ] 関連チケットにレビュー実績をつけた

## 備考

<!--
- 実装に関する悩み（AにするかBにするか迷ったがAにしたや、こうしたかったけどできなかったなど）があれば記載
-->
